### PR TITLE
Added GUI docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM pytorch/pytorch
+
+WORKDIR "/workspace"
+RUN apt-get clean \
+        && apt-get update \
+        && apt-get install -y ffmpeg libportaudio2 openssh-server python3-pyqt5 xauth gcc build-essential\
+        && apt-get -y autoremove \
+        && mkdir /var/run/sshd \
+        && mkdir /root/.ssh \
+        && chmod 700 /root/.ssh \
+        && echo "PasswordAuthentication yes" >> /etc/ssh/sshd_config \
+        && echo "X11Forwarding yes" >> /etc/ssh/sshd_config \
+        && echo "PermitRootLogin yes" >> /etc/ssh/sshd_config \
+        && echo "X11UseLocalhost yes" >> /etc/ssh/sshd_config
+RUN echo "root:root" | chpasswd
+ADD Multi-Language-RTVC/requirements.txt /workspace
+RUN pip install -r requirements.txt
+RUN echo "export PATH=/opt/conda/bin:$PATH" >> /root/.profile
+ENTRYPOINT ["sh", "-c", "/usr/sbin/sshd && bash"]
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ xhost +
 
 **SSH inside the container**
 
+Default username and password is root
 ```
 ssh -X voice
 ```

--- a/README.md
+++ b/README.md
@@ -36,6 +36,79 @@ For more information on...
 
 for both ``Windows`` and ``Linux``, visit our [Installation & Setup Wiki](https://github.com/sveneschlbeck/Multi-Language-RTVC/wiki/Installation-&-Setup).
 
+## Using Docker
+
+**Make sure you have docker and nvidia-container-toolkit installed**
+
+```
+## To install nvidia-container-toolkit
+
+# For ubuntu
+sudo apt install -y nvidia-docker2
+
+# For arch linux
+yay -S nvidia-container-toolkit
+```
+
+### Set up SSH config on the host machine
+
+#### NOTE: you need to set X11Forwarding to yes in /etc/ssh/sshd_config on the docker host as well and 
+Add the following to your SSH config at ~/.ssh/config on the docker host (or create the file if it doesn’t exists):
+
+```
+Host voice
+    Hostname localhost
+    Port 2150
+    User root
+    ForwardX11 yes
+    ForwardX11Trusted yes
+```
+
+
+**Keep the Dockerfile outside the main directory like below**
+
+![tree structure](https://user-images.githubusercontent.com/6279035/147375101-4b2df8fe-8d83-4c7f-bd91-7db60ded0abc.png)
+
+**Build the docker image**
+
+```
+docker build -t racoon-bse . 
+```
+
+**Run the Docker Container**
+
+```
+docker run -it --rm --init --gpus=all \
+        -e DISPLAY=${DISPLAY} \
+        --ipc=host --volume="$PWD:/workspace" \
+        -e NVIDIA_VISIBLE_DEVICES=0 -p 2150:22 \
+        -v /tmp/.X11-unix:/tmp/.X11-unix \
+        --device /dev/snd racoon-bse
+```
+
+**Keep the docker run tab open, and use a new window for the steps below**
+
+**Allow the connection to the X server**
+
+```
+xhost + 
+```
+
+**SSH inside the container**
+
+```
+ssh -X voice
+```
+
+**Run the apps as usual**
+
+```
+cd /workspace/Multi-Language-RTVC/mlrtvc/src
+python mlrtvc_toolbox.py
+```
+
+---
+
 ## License
 
 This code is licensed under ``MIT``. For more information regarding the license model or

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ ssh -X voice
 **Run the apps as usual**
 
 ```
+export DISPLAY=:0
+
 cd /workspace/Multi-Language-RTVC/mlrtvc/src
 python mlrtvc_toolbox.py
 ```

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ yay -S nvidia-container-toolkit
 ### Set up SSH config on the host machine
 
 #### NOTE: you need to set X11Forwarding to yes in /etc/ssh/sshd_config on the docker host as well and 
-Add the following to your SSH config at ~/.ssh/config on the docker host (or create the file if it doesn’t exists):
+Add the following to your SSH config at `~/.ssh/config` on the docker host (or create the file if it doesn’t exists):
 
 ```
 Host voice

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ docker build -t racoon-bse .
 
 ```
 docker run -it --rm --init --gpus=all \
+        --privileged \
         -e DISPLAY=${DISPLAY} \
         --ipc=host --volume="$PWD:/workspace" \
         -e NVIDIA_VISIBLE_DEVICES=0 -p 2150:22 \


### PR DESCRIPTION
i added a Dockerfile for setting up this repo. Some guides recommend venv, some virtualenv some conda, and all of them mostly don't work the same way. I created this dockerfile to run everything inside docker enviornment, so just using a few docker build and docker run command should get you this environment working. 

I'm not sure about the location for documentation, since the complete repository is empty as of now. 
I have added how do use the dockerfile under ` ## Using Docker` section in the main README.md.

To bring GUI outside this docker you need to forward X like for arch linux its

`xhost +` command. This will change depending on the OS, so feel free to add to it if you know about other OSes. 

![image](https://user-images.githubusercontent.com/6279035/147395069-7dedd1e8-9626-43f3-8adc-e1f86fb087ad.png)
