### PR TITLE
Add --skip_existing for speaker embed preprocessing

### DIFF
--- a/mlrtvc/src/core/synthesizer/preprocess.py
+++ b/mlrtvc/src/core/synthesizer/preprocess.py
@@ -302,7 +302,7 @@ def create_embeddings(
     synthesizer_root: Path,
     encoder_model_fpath: Path,
     n_processes: int,
-    skip_existing: bool
+    skip_existing: bool,
 ):
     wav_dir = synthesizer_root.joinpath("audio")
     metadata_fpath = synthesizer_root.joinpath("train.txt")
@@ -317,6 +317,10 @@ def create_embeddings(
 
     # TODO: improve on the multiprocessing, it's terrible. Disk I/O is the bottleneck here.
     # Embed the utterances in separate threads
-    func = partial(embed_utterance, encoder_model_fpath=encoder_model_fpath, skip_existing=skip_existing)
+    func = partial(
+        embed_utterance,
+        encoder_model_fpath=encoder_model_fpath,
+        skip_existing=skip_existing
+    )
     job = Pool(n_processes).imap(func, fpaths)
     list(tqdm(job, "Embedding", len(fpaths), unit="utterances"))

--- a/mlrtvc/src/core/synthesizer/preprocess.py
+++ b/mlrtvc/src/core/synthesizer/preprocess.py
@@ -299,7 +299,10 @@ def embed_utterance(fpaths, encoder_model_fpath, skip_existing):
 
 
 def create_embeddings(
-    synthesizer_root: Path, encoder_model_fpath: Path, n_processes: int, skip_existing: bool
+    synthesizer_root: Path,
+    encoder_model_fpath: Path,
+    n_processes: int,
+    skip_existing: bool
 ):
     wav_dir = synthesizer_root.joinpath("audio")
     metadata_fpath = synthesizer_root.joinpath("train.txt")

--- a/mlrtvc/src/core/synthesizer/preprocess.py
+++ b/mlrtvc/src/core/synthesizer/preprocess.py
@@ -281,12 +281,17 @@ def process_utterance(
     )
 
 
-def embed_utterance(fpaths, encoder_model_fpath):
+def embed_utterance(fpaths, encoder_model_fpath, skip_existing):
     if not encoder.is_loaded():
         encoder.load_model(encoder_model_fpath)
 
     # Compute the speaker embedding of the utterance
     wav_fpath, embed_fpath = fpaths
+    
+    # Skip existing if already embedded
+    if skip_existing and embed_fpath.exists():
+        return
+    
     wav = np.load(wav_fpath)
     wav = encoder.preprocess_wav(wav)
     embed = encoder.embed_utterance(wav)
@@ -294,7 +299,7 @@ def embed_utterance(fpaths, encoder_model_fpath):
 
 
 def create_embeddings(
-    synthesizer_root: Path, encoder_model_fpath: Path, n_processes: int
+    synthesizer_root: Path, encoder_model_fpath: Path, n_processes: int, skip_existing: bool
 ):
     wav_dir = synthesizer_root.joinpath("audio")
     metadata_fpath = synthesizer_root.joinpath("train.txt")
@@ -309,6 +314,6 @@ def create_embeddings(
 
     # TODO: improve on the multiprocessing, it's terrible. Disk I/O is the bottleneck here.
     # Embed the utterances in separate threads
-    func = partial(embed_utterance, encoder_model_fpath=encoder_model_fpath)
+    func = partial(embed_utterance, encoder_model_fpath=encoder_model_fpath, skip_existing=skip_existing)
     job = Pool(n_processes).imap(func, fpaths)
     list(tqdm(job, "Embedding", len(fpaths), unit="utterances"))

--- a/mlrtvc/src/core/synthesizer/preprocess.py
+++ b/mlrtvc/src/core/synthesizer/preprocess.py
@@ -287,11 +287,11 @@ def embed_utterance(fpaths, encoder_model_fpath, skip_existing):
 
     # Compute the speaker embedding of the utterance
     wav_fpath, embed_fpath = fpaths
-    
+
     # Skip existing if already embedded
     if skip_existing and embed_fpath.exists():
         return
-    
+
     wav = np.load(wav_fpath)
     wav = encoder.preprocess_wav(wav)
     embed = encoder.embed_utterance(wav)
@@ -320,7 +320,7 @@ def create_embeddings(
     func = partial(
         embed_utterance,
         encoder_model_fpath=encoder_model_fpath,
-        skip_existing=skip_existing
+        skip_existing=skip_existing,
     )
     job = Pool(n_processes).imap(func, fpaths)
     list(tqdm(job, "Embedding", len(fpaths), unit="utterances"))

--- a/mlrtvc/src/pre_processing/synthesizer_preprocess.py
+++ b/mlrtvc/src/pre_processing/synthesizer_preprocess.py
@@ -128,6 +128,7 @@ if __name__ == "__main__":
         encoder_model_fpath=args.encoder_model_fpath,
         n_processes=args.max_embed_processes,
         synthesizer_root=args.out_dir,
+        skip_existing=args.skip_existing,
     )
 
     # Delete args not used for mel preprocessing


### PR DESCRIPTION
Make `--skip_existing` command line argument work when preprocessing embeds.